### PR TITLE
refactor(navItem): "correctly" disabling links

### DIFF
--- a/template/layouts/default/shell/control-panel/nav-item.tsx
+++ b/template/layouts/default/shell/control-panel/nav-item.tsx
@@ -31,7 +31,7 @@ const NavItem = ({
 					href={trimExtension(target)}
 					aria-current={isActive ? 'page' : undefined}
 					data-icon-trailing={iconTrailing}
-					tabindex={disabled ? '-1' : undefined}
+					tabIndex={disabled ? '-1' : undefined}
 					aria-disabled={disabled ? 'true' : undefined}
 				>
 					{title}
@@ -67,7 +67,7 @@ const NavItem = ({
 				href={trimExtension(path)}
 				aria-current={getAriaCurrent(trimExtension(path))}
 				data-icon-trailing={iconTrailing}
-				tabindex={disabled ? '-1' : undefined}
+				tabIndex={disabled ? '-1' : undefined}
 				aria-disabled={disabled ? 'true' : undefined}
 			>
 				{title}

--- a/template/layouts/default/shell/control-panel/nav-item.tsx
+++ b/template/layouts/default/shell/control-panel/nav-item.tsx
@@ -26,12 +26,13 @@ const NavItem = ({
 				icon={icon}
 				key={`router-leaf-${target ?? title}`}
 				disabled={disabled}
-				aria-disabled={disabled ? 'true' : undefined}
 			>
 				<a
 					href={trimExtension(target)}
 					aria-current={isActive ? 'page' : undefined}
 					data-icon-trailing={iconTrailing}
+					tabindex={disabled ? '-1' : undefined}
+					aria-disabled={disabled ? 'true' : undefined}
 				>
 					{title}
 				</a>
@@ -61,12 +62,13 @@ const NavItem = ({
 			icon={icon}
 			key={`router-leaf-${path ?? title}`}
 			disabled={disabled}
-			aria-disabled={disabled ? 'true' : undefined}
 		>
 			<a
 				href={trimExtension(path)}
 				aria-current={getAriaCurrent(trimExtension(path))}
 				data-icon-trailing={iconTrailing}
+				tabindex={disabled ? '-1' : undefined}
+				aria-disabled={disabled ? 'true' : undefined}
 			>
 				{title}
 			</a>


### PR DESCRIPTION
Correctly "disabling" links in db-nav-item components. We shouldn't disable a non-interactive, purely structural element (list-item), but the links directly.