### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/a11y-scan.yml
+++ b/.github/workflows/a11y-scan.yml
@@ -4,6 +4,8 @@ on: workflow_dispatch # This configures the workflow to run manually, instead of
 jobs:
   accessibility_scanner:
     runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
+    permissions:
+      contents: read
     steps:
       - name: Generate cache key
         id: generate_cache_key


### PR DESCRIPTION
Potential fix for [https://github.com/db-ux-design-system/db-ux-design-system.github.io/security/code-scanning/2](https://github.com/db-ux-design-system/db-ux-design-system.github.io/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow or to the specific job, restricting `GITHUB_TOKEN` to the least privilege required. Since this workflow uses a separate PAT-like secret (`GH_a11y_scan`) for writing to the target repository, the `GITHUB_TOKEN` likely does not need any write access and may not need any scopes at all.

The safest, non‑functional‑changing fix here is to add `permissions: read-all` (minimal read-only) or `permissions: {}` (no permissions) at the job level. Because the job doesn’t use `GITHUB_TOKEN` explicitly and delegates repo writes to `secrets.GH_a11y_scan`, we can set `permissions: read-all` to keep logs/artifact reads working in case the action or future steps rely on them, while still constraining any unintended write access. Concretely, in `.github/workflows/a11y-scan.yml`, under the `accessibility_scanner` job (just after `runs-on: ubuntu-24.04`), add:

```yaml
    permissions:
      contents: read
```

This gives only read access to repo contents, which is a very common minimal set and adheres to “least privilege” while preserving benign read behaviors. No imports or additional methods are required, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
