### PR TITLE
feat(dependabot): added support for AI reviews

### DIFF
--- a/.github/workflows/99-dependabot-review.yml
+++ b/.github/workflows/99-dependabot-review.yml
@@ -1,0 +1,19 @@
+---
+name: Dependabot review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_call:
+
+jobs:
+  review:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-24.04 # Use Ubuntu 24.04 explicitly
+    steps:
+      - name: Prepare dependency review prompt
+        uses: mfranzke/dependabot-review-action@f978694098c8d903eaeb3d4d5b02e25d1c31fe63 # v0.1.0
+        with:
+          github-token: ${{ github.token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,3 +17,6 @@ jobs:
 
   dependency-review:
     uses: ./.github/workflows/99-dependency-review.yml
+
+  dependabot-review:
+    uses: ./.github/workflows/99-dependabot-review.yml


### PR DESCRIPTION
We'd like to fetch all relevant information (changelog, but especially all code changes as well, as only the latter include the whole "truth" of what has changed) to do a complementary AI powered review for a dependabot PR.