### PR TITLE
feat(docs): german translation for MCP server learn page

### DIFF
--- a/content/pages/de/dokumentation/lernen/mcp-server.mdx
+++ b/content/pages/de/dokumentation/lernen/mcp-server.mdx
@@ -1,0 +1,352 @@
+---
+layout: '@template/layouts/documentation'
+sectionSpacing: 'small'
+sectionWidth: 'auto'
+title: 'MCP Server'
+headline: 'MCP Server'
+description: 'Verbinde KI-Coding-Agents über das Model Context Protocol mit dem DB UX Design System. Du erhältst korrekte Komponenten-APIs, Design Tokens und Code-Beispiele – ohne Halluzinationen.'
+align: start
+toc: true
+tocMaxDepth: 2
+---
+
+import { DBSection } from '@db-ux/react-core-components';
+
+<DBSection spacing="small" width="auto">
+
+## Einführung & Voraussetzungen
+
+Der **DB UX MCP Server** ist die Brücke zwischen KI-Coding-Agents (GitHub Copilot, Amazon Q, Claude, Cursor) und dem DB UX Design System. Er stellt jedem Agent eine einzige verlässliche Quelle für Komponenten-APIs, Framework-spezifische Code-Beispiele, Design Tokens und Icon-Namen bereit – der Agent muss also nie raten oder halluzinieren.
+
+Ohne diesen Server erfinden KI-Agents plausibel klingende, aber falsche Komponentenverwendungen. Mit ihm greifen sie auf den exakten generierten Quellcode zu, der in den Node-Paketen (npm) ausgeliefert wird.
+
+### Voraussetzungen
+
+| Anforderung        | Details                                             |
+| ------------------ | --------------------------------------------------- |
+| **Node.js**        | **v22.0.0 oder höher** (erforderlich)               |
+| **npm**            | Bei Node.js enthalten                               |
+| **MCP-fähige IDE** | VS Code, IntelliJ/JetBrains, Cursor, Amazon Q, Kiro |
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+## Schnellstart & Installation
+
+### Schritt 1: Server registrieren
+
+Der Server wird über `npx` in deine IDE eingebunden:
+
+```bash
+npx --yes @db-ux/mcp-server
+```
+
+> **Wichtig:** Führe diesen Befehl **nicht** manuell im Terminal aus. Deine IDE startet ihn automatisch im Hintergrund. Bei manueller Ausführung scheint das Terminal zu "hängen", weil der Server auf JSON-RPC-Nachrichten über `stdio` wartet.
+
+### Schritt 2: Installation im Projekt
+
+Installiere den Server:
+
+```bash
+npm i --save-dev @db-ux/mcp-server
+```
+
+### Schritt 3: Projekt-Regeln generieren
+
+Die `@db-ux/agent-cli` kopiert die offiziellen DB UX Regeln (Komponentenverwendung, Referenzierung von Design Tokens) in dein Repository:
+
+```bash
+npx --yes @db-ux/agent-cli
+```
+
+Dabei entsteht eine `.github/copilot-instructions.md` im Projekt-Root. Diese Datei stellt sicher, dass der KI-Agent DB UX Komponenten korrekt verwendet und keine falschen Verwendungsmuster erfindet.
+
+### Schritt 4: Verbindung prüfen
+
+- **Status prüfen:** Achte auf einen grünen Indikator oder den Eintrag "db-ux" in der MCP-Server-Liste deiner IDE.
+- **Logs prüfen:** Wenn der Server nicht erscheint, sieh in den MCP-Output-Logs nach (z. B. in VS Code: _Output Panel_ → _MCP_ oder _MCP Servers_).
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+## IDE-Konfiguration
+
+Alle IDEs benötigen dieselbe Basiskonfiguration:
+
+```json
+{
+	"mcpServers": {
+		"db-ux": {
+			"command": "npx",
+			"args": ["--yes", "@db-ux/mcp-server"]
+		}
+	}
+}
+```
+
+### VS Code
+
+Du hast 2 Möglichkeiten:
+
+#### Variante A: Auf Projektebene (empfohlen)
+
+Lege eine `.vscode/mcp.json` im Projekt-Root an. Diese Datei kann über Git geteilt werden:
+
+```json
+{
+	"servers": {
+		"db-ux": {
+			"command": "npx",
+			"args": ["--yes", "@db-ux/mcp-server"]
+		}
+	}
+}
+```
+
+#### Variante B: Auf Nutzerebene
+
+Ergänze den Eintrag in deiner globalen `settings.json` (dasselbe JSON wie oben, unter `mcp` auf der obersten Ebene):
+
+```json
+{
+	"mcp": {
+		"servers": {
+			"db-ux": {
+				"command": "npx",
+				"args": ["--yes", "@db-ux/mcp-server"]
+			}
+		}
+	}
+}
+```
+
+> **Hinweis:** Wenn beide existieren, hat `.vscode/mcp.json` Vorrang.
+
+<br />
+
+> **⚠️ Warnung "Unknown Configuration Setting":** Wenn VS Code eine gelbe Warnung am `mcp`-Key anzeigt, ist das erwartetes Verhalten. Standard-VS-Code kennt den Key nicht von sich aus. Solange dein MCP-Client (z. B. Copilot Chat oder Cursor) aktiv ist, funktioniert der Server korrekt.
+
+### IntelliJ / JetBrains IDEs
+
+Gehe zu _Settings → Tools → AI Assistant → Model Context Protocol (MCP)_ und klicke auf _Add (+)_. Trage folgende Werte ein:
+
+| Feld          | Wert                      |
+| ------------- | ------------------------- |
+| **Name**      | `db-ux`                   |
+| **Type**      | `stdio`                   |
+| **Command**   | `npx`                     |
+| **Arguments** | `--yes @db-ux/mcp-server` |
+
+### Amazon Q / Kiro
+
+Amazon Q kann die `CONTEXT.md` des Projekts automatisch als dauerhaften System-Prompt laden. Damit kennt der Agent **ab der ersten Nachricht** die komplette Architektur des MCP Servers, alle Tools, Design Tokens, Migrations-Workflows und die v3-Komponenten-API.
+
+**Vorteile:**
+
+- ✅ Verhindert Halluzinationen bei Komponentennamen, Prop-Signaturen und Token-Werten
+- ✅ Führt den Agenten ab der ersten Nachricht durch den korrekten Migrations-Workflow
+- ✅ Gibt neuen Teammitgliedern direkt einen kontextbewussten KI-Assistenten
+
+**Einrichtung:**
+
+1. Öffne (oder erstelle) `~/.aws/amazonq/agents/default.json`.
+2. Ergänze folgende Konfiguration:
+
+```json
+{
+	"agentInstruction": {
+		"paths": ["CONTEXT.md"]
+	}
+}
+```
+
+3. Stelle sicher, dass die `CONTEXT.md` im Projekt-Root liegt (wird von `npx @db-ux/agent-cli` kopiert).
+
+> **Hinweis:** Der Pfad wird relativ zum Workspace-Root aufgelöst. Amazon Q / Kiro liest diese Datei zu Beginn jeder Session und fügt sie als System-Kontext ein.
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+## Verfügbare Tools (API-Referenz)
+
+### Discovery
+
+| Tool                    | Beschreibung                                                                                                                           |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_components`       | Gibt alle verfügbaren DB UX Komponentennamen zurück (z. B. `button`, `input`, `tag`). **Immer zuerst aufrufen.**                       |
+| `get_component_props`   | Gibt den rohen TypeScript-Inhalt der `model.ts` zurück – alle Interfaces, Prop-Typen und JSDoc-Kommentare.                             |
+| `get_component_details` | Listet die verfügbaren Beispielnamen einer Komponente auf (z. B. `"Variant"`, `"Show Icon Leading"`).                                  |
+| `get_example_code`      | Gibt den exakten generierten Quellcode eines Beispiels für ein Framework zurück (`react`, `angular`, `vue`, `web-components`, `html`). |
+
+### Tokens & Assets
+
+| Tool                           | Beschreibung                                                                                                                     |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `get_design_tokens`            | Gibt CSS Custom Properties (`--db-*`) für eine Token-Kategorie zurück. Spacing, Elevation und Density liefern kompilierte Werte. |
+| `list_design_token_categories` | Listet alle verfügbaren Token-Kategorien auf (z. B. `colors`, `spacing`, `typography`, `elevation`, `density`).                  |
+| `list_icons`                   | Gibt alle gültigen DB UX Icon-Namen zurück. **Immer aufrufen, bevor eine `icon`-Property gesetzt wird.**                         |
+| `get_component_visual`         | Gibt einen verkleinerten Screenshot (max. 800×800 px, JPEG q75) als Base64 zurück. Nur bei Bedarf verwenden.                     |
+| `docs_search`                  | Durchsucht die DB UX Dokumentation (Richtlinien, Barrierefreiheit, Migrations-Dokus). Funktioniert als RAG-Engine.               |
+
+### Migration & Scaffolding
+
+| Tool                    | Beschreibung                                                                                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `analyze_v2_migration`  | **Bei Migrationen zuerst aufrufen.** Scannt eine Datei nach DB UI v2 Patterns (`<cmp-*>`, `<elm-*>`, `db-color-*`) und gibt einen JSON-Report zurück. |
+| `list_migration_guides` | Gibt alle verfügbaren Migration Guides zurück (z. B. `color-migration`, `component-migration`).                                                       |
+| `get_migration_guide`   | Gibt den vollständigen Markdown-Inhalt eines Migration Guides zurück.                                                                                 |
+| `verify_migrated_code`  | Speichert generierten Code temporär und prüft ihn mit `tsc --noEmit`. Gibt bei Fehlern Diagnostics zurück (max. 3 Versuche).                          |
+| `scaffold_component`    | Generiert ein DB UX konformes Komponenten-Grundgerüst für ein Framework mit korrekten `@db-ux/*`-Imports und SCSS-`@use`-Direktiven.                  |
+
+### Beispiel-Workflow: React Button
+
+```text
+list_components          → bestätigt, dass "button" existiert
+get_component_props      → zeigt DBButtonProps, Varianten, Typen
+get_component_details    → listet ["Density", "Variant", "Show Icon Leading", ...]
+get_example_code         → gibt den Quellcode von show-icon-leading.example.tsx zurück
+list_icons               → bestätigt, dass "arrow_right" ein gültiger Icon-Name ist
+get_design_tokens        → gibt --db-spacing-fixed-md für das Layout zurück
+verify_migrated_code     → prüft den generierten Code via tsc --noEmit
+```
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+## Workflows & Prompts nutzen
+
+Der Server stellt vordefinierte **Prompts** bereit, die komplexe KI-Workflows orchestrieren. Du rufst sie über die Chat-UI deiner IDE auf (sofern unterstützt) oder über den MCP Inspector.
+
+### `scaffold_page` – Rapid Prototyping
+
+Generiert die Grundstruktur einer kompletten Webseite oder eines komplexen Moduls.
+
+| Parameter                 | Beschreibung                               |
+| ------------------------- | ------------------------------------------ |
+| `page_type`               | Art der Seite (z. B. `dashboard`, `form`)  |
+| `framework`               | Ziel-Framework (`react`, `angular`, `vue`) |
+| `additional_requirements` | Optionale zusätzliche Anforderungen        |
+
+### `migrate_component` – Legacy-Migration
+
+Überführt Legacy-Code (Bootstrap, natives HTML, DB UI v1/v2) in die moderne DB UX v3 Architektur. Orchestriert **12 verschiedene MCP Tools** in 5 verpflichtenden Schritten mit Compiler-geprüfter Selbstkorrektur.
+
+| Parameter          | Erforderlich | Beschreibung                                                        |
+| ------------------ | ------------ | ------------------------------------------------------------------- |
+| `legacy_code`      | Ja           | Der zu migrierende Quellcode (max. 10.000 Zeichen)                  |
+| `source_context`   | Ja           | Herkunft: `db-ui-v1`, `db-ui-v2`, `bootstrap-4`, `native-html` usw. |
+| `target_framework` | Ja           | Ziel: `react`, `angular`, `vue`, `web-components`, `html`           |
+
+**Workflow-Schritte:**
+
+```text
+Schritt 0: analyze_v2_migration   → Datei-Scan (deterministisch, kein Raten)
+Schritt 1: Migrations-Analyse     → Mapping-Tabelle: Legacy → DB UX v3
+Schritt 2: Component Discovery    → Props, Beispiele, Tokens, Icons laden
+Schritt 3: Code-Generierung       → vollständig migrierter Code (intern)
+Schritt 4: verify_migrated_code   → Compiler-Prüfung + Selbstkorrektur (max. 3×)
+Schritt 5: Finale Ausgabe         → ✅ VERIFIED oder ⚠️ WARNING + Diagnostics
+```
+
+### `review_ui_code` – Qualitätssicherung & Barrierefreiheit
+
+Führt ein strenges Audit zu Qualität, Barrierefreiheit und DB UX Konformität für einen Code-Ausschnitt durch.
+
+| Parameter      | Beschreibung                   |
+| -------------- | ------------------------------ |
+| `code_snippet` | Der zu prüfende Quellcode      |
+| `framework`    | Framework des Code-Ausschnitts |
+
+### `audit_accessibility` – Erweiterter A11y-Scan
+
+Spezialisierter Scan auf WCAG 2.2 AA Konformität. Bewertet interaktive Patterns und Fokusreihenfolgen und generiert manuelle Testskripte für QA-Engineers.
+
+| Parameter      | Beschreibung                   |
+| -------------- | ------------------------------ |
+| `code_snippet` | Der zu prüfende Quellcode      |
+| `framework`    | Framework des Code-Ausschnitts |
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+## Troubleshooting & Debugging
+
+### "Unknown Configuration Setting" in VS Code
+
+**Problem:** Gelbe Warnung am `mcp`-Key in der `settings.json`.
+
+**Ursache:** Standard-VS-Code kennt den Key nicht von sich aus. Das ist erwartetes Verhalten.
+
+**Lösung:** Ignoriere die Warnung. Solange dein MCP-Client (Copilot Chat, Cursor) aktiv ist, funktioniert der Server korrekt.
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+### Server startet nicht aus dem Monorepo-Root
+
+**Problem:** `npx @db-ux/mcp-server` schlägt wegen der npm-Workspace-Auflösung fehl.
+
+**Lösung:** Verwende `node` direkt mit dem lokalen Build-Pfad:
+
+```json
+{
+	"db-ux": {
+		"command": "node",
+		"args": ["packages/mcp-server/dist/index.js"]
+	}
+}
+```
+
+> Voraussetzung: Führe vorher `npm run build` im Verzeichnis `mcp-server` aus.
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+### MCP Inspector – Tools isoliert testen
+
+Der **MCP Inspector** ist das offizielle Werkzeug, um MCP Tools und Prompts unabhängig von der IDE zu prüfen.
+
+**Server bauen, falls nötig:**
+
+```bash
+cd packages/mcp-server && npm run build
+```
+
+**Inspector starten:**
+
+```bash
+npx @modelcontextprotocol/inspector --transport stdio node dist/index.js
+```
+
+> **Hinweis:** Der Inspector nutzt Port **6274** (UI) und **6277** (Proxy). Wenn belegt: `lsof -ti :6274 -ti :6277 | xargs kill -9`
+
+**Ablauf:**
+
+1. Führe den Befehl aus – der Inspector startet einen lokalen Webserver.
+2. Öffne die vollständige URL **inklusive Token** im Browser (z. B. `http://localhost:6274/?MCP_PROXY_AUTH_TOKEN=...`).
+3. Klicke auf **"Connect"**.
+4. Rufe im Tab **"Tools"** einzelne Tools auf und prüfe die Antworten.
+5. Teste im Tab **"Prompts"** interaktive Prompts wie `scaffold_page`.
+
+</DBSection>
+
+<DBSection spacing="small" width="auto">
+
+## Weitere Ressourcen
+
+| Ressource             | Link                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------ |
+| **GitHub Repository** | [db-ux-design-system/core-web](https://github.com/db-ux-design-system/core-web)                  |
+| **npm: MCP Server**   | [@db-ux/mcp-server](https://www.npmjs.com/package/@db-ux/mcp-server)                             |
+| **npm: Agent CLI**    | [@db-ux/agent-cli](https://www.npmjs.com/package/@db-ux/agent-cli)                               |
+| **MCP-Spezifikation** | [modelcontextprotocol.io](https://modelcontextprotocol.io)                                       |
+| **MCP Inspector**     | [@modelcontextprotocol/inspector](https://www.npmjs.com/package/@modelcontextprotocol/inspector) |
+
+</DBSection>


### PR DESCRIPTION
Adds the German translation of the MCP server learn page at `content/pages/de/dokumentation/lernen/mcp-server.mdx`.